### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+labels: bug
+about: If something isn't working as expected.
+---
+
+# What did you do? (required. The issue will be **closed** when not provided.)
+
+
+# What did you expect to happen?
+
+
+# What happened instead?
+
+* Current Output
+
+Please re-run the command using ```-debug``` and provide the output below.
+
+# Steps to reproduce the behaviour
+
+
+# Configuration (**MUST** fill this out):
+
+* Go version (`go version`):
+
+* Go environment (`go env`):
+
+* go-cpe-dictionary environment:
+
+Hash : ____
+
+To check the commit hash of HEAD
+$ go-cpe-dictionary version
+
+or
+
+$ cd $GOPATH/src/github.com/vulsio/go-cpe-dictionary 
+$ git rev-parse --short HEAD 
+
+* command:
+

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,9 @@
+---
+name: Feature Request
+labels: enhancement
+about: I have a suggestion (and might want to implement myself)!
+---
+
+<!--
+If this is a FEATURE REQUEST, request format does not matter!
+-->

--- a/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
@@ -1,0 +1,10 @@
+---
+name: Support Question
+labels: question
+about: If you have a question about Vuls.
+---
+
+<!--
+If you have a trouble, feel free to ask.
+Make sure you're not asking duplicate question by searching on the issues lists.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+
+If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.
+
+# What did you implement:
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
+
+# Checklist:
+You don't have to satisfy all of the following.
+
+- [ ] Write tests
+- [ ] Write documentation
+- [ ] Check that there aren't other open pull requests for the same issue/feature
+- [ ] Format your source code by `make fmt`
+- [ ] Pass the test by `make test`
+- [ ] Provide verification config / commands
+- [ ] Enable "Allow edits from maintainers" for this PR
+- [ ] Update the messages below
+
+***Is this ready for review?:*** NO  
+
+# Reference
+
+* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
+

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,39 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
-    #  misspell:
+  #  misspell:
     #ignore-words:
     #  - Criterias
 
@@ -11,9 +41,9 @@ linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
-      #- misspell
+    - misspell
     - errcheck
     - staticcheck
     - prealloc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
+  ldflags: -s -w -X github.com/vulsio/go-cpe-dictionary/config.Version={{.Version}} -X github.com/vulsio/go-cpe-dictionary/config.Revision={{.Commit}}
   binary: go-cpe-dictionary
 archives:
 - name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -24,7 +24,7 @@ func init() {
 	fetchCmd.AddCommand(fetchJvnCmd)
 }
 
-func fetchJvn(cmd *cobra.Command, args []string) (err error) {
+func fetchJvn(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -24,7 +24,7 @@ func init() {
 	fetchCmd.AddCommand(fetchNvdCmd)
 }
 
-func fetchNvd(cmd *cobra.Command, args []string) (err error) {
+func fetchNvd(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -27,7 +27,7 @@ func init() {
 	_ = viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -41,7 +41,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: logger.New(
@@ -241,7 +241,7 @@ func (r *RDBDriver) deleteAndInsertCpes(conn *gorm.DB, fetchType models.FetchTyp
 }
 
 // IsDeprecated : IsDeprecated
-func (r *RDBDriver) IsDeprecated(cpeURI string) (bool, error) {
+func (r *RDBDriver) IsDeprecated(_ string) (bool, error) {
 	// not implemented yet
 	return false, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -66,7 +66,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (bool, error) {
+func (r *RedisDriver) OpenDB(_, dbPath string, _ bool, option Option) (bool, error) {
 	return false, r.connectRedis(dbPath, option)
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -5,7 +5,7 @@ import "gorm.io/gorm"
 // LatestSchemaVersion manages the Schema version used in the latest go-cpe-dictionary.
 const LatestSchemaVersion = 2
 
-// FetchMeta has meta infomation about fetched data
+// FetchMeta has meta information about fetched data
 type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GoCPEDictRevision string


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

