### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -48,6 +48,11 @@ func fetchJvn(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	cpes, err := fetcher.FetchJVN()
 	if err != nil {
 		log15.Error("Failed to fetch.", "err", err)
@@ -61,11 +66,6 @@ func fetchJvn(cmd *cobra.Command, args []string) (err error) {
 			return fmt.Errorf("Failed to insert cpes. err : %s", err)
 		}
 		log15.Info(fmt.Sprintf("Inserted %d CPEs", len(cpes)))
-
-		if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-			log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-			return err
-		}
 	} else {
 		for _, cpe := range cpes {
 			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%t\n",

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -48,6 +48,11 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	cpes, err := fetcher.FetchNVD()
 	if err != nil {
 		log15.Error("Failed to fetch.", "err", err)
@@ -61,11 +66,6 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 			return fmt.Errorf("Failed to insert cpes. err : %s", err)
 		}
 		log15.Info(fmt.Sprintf("Inserted %d CPEs", len(cpes)))
-
-		if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-			log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-			return err
-		}
 	} else {
 		for _, cpe := range cpes {
 			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%t\n",


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

