### PR TITLE
fix(redis): update Redis key relationship successfully

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -20,16 +20,16 @@ import (
 /**
 # Redis Data Structure
 - Sets
-  ┌─────────────────────────────┬──────────────────────┬──────────────────────────────────┐
-  │       KEY                   │  MEMBER              │             PURPOSE              │
-  └─────────────────────────────┴──────────────────────┴──────────────────────────────────┘
-  ┌─────────────────────────────┬──────────────────────┬──────────────────────────────────┐
-  │ CPE#VendorProducts          │ ${vendor}#${product} │ Get ALL Vendor Products          │
-  ├─────────────────────────────┼──────────────────────┼──────────────────────────────────┤
-  │ CPE#VP#${vendor}#${product} │ CPEURI               │ Get CPEURI by vendor and product │
-  ├─────────────────────────────┼──────────────────────┼──────────────────────────────────┤
-  │ CPE#DeprecatedCPEs          │ CPEURI               │ Get DeprecatedCPEs               │
-  └─────────────────────────────┴──────────────────────┴──────────────────────────────────┘
+  ┌─────────────────────────────┬───────────────────────┬──────────────────────────────────┐
+  │       KEY                   │  MEMBER               │             PURPOSE              │
+  └─────────────────────────────┴───────────────────────┴──────────────────────────────────┘
+  ┌─────────────────────────────┬───────────────────────┬──────────────────────────────────┐
+  │ CPE#VendorProducts          │ ${vendor}##${product} │ Get ALL Vendor Products          │
+  ├─────────────────────────────┼───────────────────────┼──────────────────────────────────┤
+  │ CPE#VP#${vendor}##${product} │ CPEURI               │ Get CPEURI by vendor and product │
+  ├─────────────────────────────┼───────────────────────┼──────────────────────────────────┤
+  │ CPE#DeprecatedCPEs          │ CPEURI                │ Get DeprecatedCPEs               │
+  └─────────────────────────────┴───────────────────────┴──────────────────────────────────┘
 
 - Hash
   ┌───┬────────────────┬───────────────┬────────┬──────────────────────────────────────────────────┐
@@ -46,7 +46,7 @@ import (
 
 const (
 	dialectRedis      = "redis"
-	vpKeyFormat       = "CPE#VP#%s#%s"
+	vpKeyFormat       = "CPE#VP#%s##%s"
 	vpListKey         = "CPE#VendorProducts"
 	vpSeparator       = "##"
 	deprecatedCPEsKey = "CPE#DeprecatedCPEs"
@@ -263,7 +263,7 @@ func (r *RedisDriver) InsertCpes(fetchType models.FetchType, cpes []models.Categ
 	pipe := r.conn.Pipeline()
 	for vendorProductStr, cpeURIs := range oldDeps["VP"] {
 		for cpeURI := range cpeURIs {
-			ss := strings.Split(vendorProductStr, "#")
+			ss := strings.Split(vendorProductStr, vpSeparator)
 			_ = pipe.SRem(ctx, fmt.Sprintf(vpKeyFormat, ss[0], ss[1]), cpeURI)
 		}
 	}


### PR DESCRIPTION
# What did you implement:
There was a bug in the update method of deleting outdated information in the DB at the time of Redis fetch, causing more information than necessary to be deleted.This bug has been fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The separator of the vendorProductStr is `##`, but since it tries to split with `#`, ss[1] becomes "", and SRem is executed for the strange key.
https://github.com/vulsio/go-cpe-dictionary/blob/master/db/redis.go#L272

## master
```console
$ go-cpe-dictionary fetch  --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HSET CPE#DEP jvn '{"DeprecatedCPEs": {}, "VP": {"test_vendor##test_product": { "cpe:/a:test_vendor:test_product": {} }}, "VendorProducts": {}}'
(integer) 0
127.0.0.1:6379> SADD CPE#VP#test_vendor##test_product cpe:/a:test_vendor:test_product
(integer) 1

$ go-cpe-dictionary fetch  --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS CPE#VP#test_vendor##test_product
1) "cpe:/a:test_vendor:test_product" // bug
```

### MaineK00n/fix-update-deps
```console
$ go-cpe-dictionary fetch  --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HSET CPE#DEP jvn '{"DeprecatedCPEs": {}, "VP": {"test_vendor##test_product": { "cpe:/a:test_vendor:test_product": {} }}, "VendorProducts": {}}'
127.0.0.1:6379> SADD CPE#VP#test_vendor##test_product cpe:/a:test_vendor:test_product

$ go-cpe-dictionary fetch  --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS CPE#VP#test_vendor##test_product
(empty array)
127.0.0.1:6379> EXISTS CPE#VP#test_vendor##test_product
(integer) 0
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
