### PR TITLE
feat(db): add LastFetchedDate in fetchmeta

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -82,7 +82,7 @@ func fetchJvn(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -82,7 +82,7 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -42,9 +43,9 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -79,6 +80,11 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 				cpe.Deprecated,
 			)
 		}
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/commands/server.go
+++ b/commands/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vulsio/go-cpe-dictionary/db"
+	"github.com/vulsio/go-cpe-dictionary/models"
 	"github.com/vulsio/go-cpe-dictionary/server"
 	"github.com/vulsio/go-cpe-dictionary/util"
 	"golang.org/x/xerrors"
@@ -37,7 +38,15 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
+	}
+
+	fetchMeta, err := driver.GetFetchMeta()
+	if err != nil {
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+	}
+	if fetchMeta.OutDated() {
+		return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	log15.Info("Starting HTTP Server...")

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -150,7 +150,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -150,7 +150,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -33,18 +33,18 @@ import (
   └─────────────────────────────┴──────────────────────┴──────────────────────────────────┘
 
 - Hash
-  ┌───┬────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │NO │    KEY         │   FIELD         │  VALUE      │                     PURPOSE                      │
-  └───┴────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
-  ┌───┬────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
-  │ 1 │ CPE#DEP        │    NVD/JVN      │  JSON       │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
-  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ 2 │ CPE#FETCHMETA  │   Revision      │ string      │ GET Go-Cpe-Dictionary Binary Revision            │
-  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ 3 │ CPE#FETCHMETA  │ SchemaVersion   │  uint       │ GET Go-Cpe-Dictionary Schema Version             │
-  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
-  │ 4 │ CPE#FETCHMETA  │ LastFetchedDate │  time.Time  │ GET Go-Cpe-Dictionary Last Fetched Time          │
-  └───┴────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌───┬────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │NO │    KEY         │   FIELD       │  VALUE      │                     PURPOSE                      │
+  └───┴────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌───┬────────────────┬───────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │ 1 │ CPE#DEP        │    NVD/JVN    │  JSON       │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
+  ├───┼────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 2 │ CPE#FETCHMETA  │   Revision    │ string      │ GET Go-Cpe-Dictionary Binary Revision            │
+  ├───┼────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 3 │ CPE#FETCHMETA  │ SchemaVersion │  uint       │ GET Go-Cpe-Dictionary Schema Version             │
+  ├───┼────────────────┼───────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 4 │ CPE#FETCHMETA  │ LastFetchedAt │  time.Time  │ GET Go-Cpe-Dictionary Last Fetched Time          │
+  └───┴────────────────┴───────────────┴─────────────┴──────────────────────────────────────────────────┘
 **/
 
 const (
@@ -129,7 +129,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -146,10 +146,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedAt").Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedAt. err: %w", err)
 		}
 		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
@@ -158,12 +158,12 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
 	}
 
-	return &models.FetchMeta{GoCPEDictRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
+	return &models.FetchMeta{GoCPEDictRevision: revision, SchemaVersion: uint(version), LastFetchedAt: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedAt": fetchMeta.LastFetchedAt}).Err()
 }
 
 // GetVendorProducts : GetVendorProducts

--- a/db/redis.go
+++ b/db/redis.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-redis/redis/v8"
@@ -32,16 +33,18 @@ import (
   └─────────────────────────────┴──────────────────────┴──────────────────────────────────┘
 
 - Hash
-  ┌───┬────────────────┬───────────────┬────────┬──────────────────────────────────────────────────┐
-  │NO │    KEY         │   FIELD       │  VALUE │                     PURPOSE                      │
-  └───┴────────────────┴───────────────┴────────┴──────────────────────────────────────────────────┘
-  ┌───┬────────────────┬───────────────┬────────┬──────────────────────────────────────────────────┐
-  │ 1 │ CPE#DEP        │    NVD/JVN    │  JSON  │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
-  ├───┼────────────────┼───────────────┼────────┼──────────────────────────────────────────────────┤
-  │ 2 │ CPE#FETCHMETA  │   Revision    │ string │ GET Go-Cpe-Dictionary Binary Revision            │
-  ├───┼────────────────┼───────────────┼────────┼──────────────────────────────────────────────────┤
-  │ 3 │ CPE#FETCHMETA  │ SchemaVersion │  uint  │ GET Go-Cpe-Dictionary Schema Version             │
-  └───┴────────────────┴───────────────┴────────┴──────────────────────────────────────────────────┘
+  ┌───┬────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │NO │    KEY         │   FIELD         │  VALUE      │                     PURPOSE                      │
+  └───┴────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
+  ┌───┬────────────────┬─────────────────┬─────────────┬──────────────────────────────────────────────────┐
+  │ 1 │ CPE#DEP        │    NVD/JVN      │  JSON       │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER │
+  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 2 │ CPE#FETCHMETA  │   Revision      │ string      │ GET Go-Cpe-Dictionary Binary Revision            │
+  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 3 │ CPE#FETCHMETA  │ SchemaVersion   │  uint       │ GET Go-Cpe-Dictionary Schema Version             │
+  ├───┼────────────────┼─────────────────┼─────────────┼──────────────────────────────────────────────────┤
+  │ 4 │ CPE#FETCHMETA  │ LastFetchedDate │  time.Time  │ GET Go-Cpe-Dictionary Last Fetched Time          │
+  └───┴────────────────┴─────────────────┴─────────────┴──────────────────────────────────────────────────┘
 **/
 
 const (
@@ -126,7 +129,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GoCPEDictRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -143,12 +146,21 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	return &models.FetchMeta{GoCPEDictRevision: revision, SchemaVersion: uint(version)}, nil
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+	}
+	date, err := time.Parse(time.RFC3339, datestr)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
+	}
+
+	return &models.FetchMeta{GoCPEDictRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": fetchMeta.GoCPEDictRevision, "SchemaVersion": fetchMeta.SchemaVersion}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
 }
 
 // GetVendorProducts : GetVendorProducts

--- a/db/redis.go
+++ b/db/redis.go
@@ -148,7 +148,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		if !errors.Is(err, redis.Nil) {
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		}
+		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
 	date, err := time.Parse(time.RFC3339, datestr)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -1,6 +1,10 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // LatestSchemaVersion manages the Schema version used in the latest go-cpe-dictionary.
 const LatestSchemaVersion = 2
@@ -10,6 +14,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GoCPEDictRevision string
 	SchemaVersion     uint
+	LastFetchedDate   time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated

--- a/models/models.go
+++ b/models/models.go
@@ -14,7 +14,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GoCPEDictRevision string
 	SchemaVersion     uint
-	LastFetchedDate   time.Time
+	LastFetchedAt     time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated


### PR DESCRIPTION
# What did you implement:
Add the time when the fetch is completed to fetchmeta.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## RDB
```console
$ go-cpe-dictionary fetch nvd
$ sqlite3 cpe.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 08:57:10.363973959+09:00

$ go-cpe-dictionary fetch nvd
$ sqlite3 cpe.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 08:59:27.598942689+09:00
```

## Redis
```console
$ redis-cli -p 6379
127.0.0.1:6379> HGET CPE#FETCHMETA LastFetchedAt
(nil)

$ go-cpe-dictionary fetch nvd --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET CPE#FETCHMETA LastFetchedAt
"2021-12-26T09:33:39.507090485+09:00"

$ go-cpe-dictionary fetch nvd --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET CPE#FETCHMETA LastFetchedAt
"2021-12-26T09:35:22.234022854+09:00"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
