### PR TITLE
refactor(fetch/nvd): reduced memory by reading in stream

### DIFF
--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -17,12 +17,6 @@ var fetchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 
-	fetchCmd.PersistentFlags().Bool("stdout", false, "display all CPEs to stdout")
-	_ = viper.BindPFlag("stdout", fetchCmd.PersistentFlags().Lookup("stdout"))
-
-	fetchCmd.PersistentFlags().Int("wait", 0, "Interval between fetch (seconds)")
-	_ = viper.BindPFlag("wait", fetchCmd.PersistentFlags().Lookup("wait"))
-
 	fetchCmd.PersistentFlags().Int("threads", runtime.NumCPU(), "The number of threads to be used")
 	_ = viper.BindPFlag("threads", fetchCmd.PersistentFlags().Lookup("threads"))
 

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -24,6 +22,9 @@ var fetchJvnCmd = &cobra.Command{
 
 func init() {
 	fetchCmd.AddCommand(fetchJvnCmd)
+
+	fetchJvnCmd.PersistentFlags().Int("wait", 0, "Interval between fetch (seconds)")
+	_ = viper.BindPFlag("wait", fetchJvnCmd.PersistentFlags().Lookup("wait"))
 }
 
 func fetchJvn(_ *cobra.Command, _ []string) (err error) {
@@ -55,32 +56,8 @@ func fetchJvn(_ *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
-	log15.Info("Fetched", "Number of CPEs", len(cpes))
-
-	if !viper.GetBool("stdout") {
-		if err = driver.InsertCpes(models.JVN, cpes); err != nil {
-			return xerrors.Errorf("Failed to insert cpes. err: %w", err)
-		}
-		log15.Info(fmt.Sprintf("Inserted %d CPEs", len(cpes)))
-	} else {
-		for _, cpe := range cpes {
-			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%t\n",
-				cpe.CpeURI,
-				cpe.CpeFS,
-				cpe.Part,
-				cpe.Vendor,
-				cpe.Product,
-				cpe.Version,
-				cpe.Update,
-				cpe.Edition,
-				cpe.Language,
-				cpe.SoftwareEdition,
-				cpe.TargetSoftware,
-				cpe.TargetHardware,
-				cpe.Other,
-				cpe.Deprecated,
-			)
-		}
+	if err := driver.InsertCpes(models.JVN, cpes); err != nil {
+		return xerrors.Errorf("Failed to insert cpes. err: %w", err)
 	}
 
 	fetchMeta.LastFetchedAt = time.Now()

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -55,32 +53,8 @@ func fetchNvd(_ *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
-	log15.Info("Fetched", "Number of CPEs", len(cpes))
-
-	if !viper.GetBool("stdout") {
-		if err = driver.InsertCpes(models.NVD, cpes); err != nil {
-			return xerrors.Errorf("Failed to insert cpes. err: %w", err)
-		}
-		log15.Info(fmt.Sprintf("Inserted %d CPEs", len(cpes)))
-	} else {
-		for _, cpe := range cpes {
-			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%t\n",
-				cpe.CpeURI,
-				cpe.CpeFS,
-				cpe.Part,
-				cpe.Vendor,
-				cpe.Product,
-				cpe.Version,
-				cpe.Update,
-				cpe.Edition,
-				cpe.Language,
-				cpe.SoftwareEdition,
-				cpe.TargetSoftware,
-				cpe.TargetHardware,
-				cpe.Other,
-				cpe.Deprecated,
-			)
-		}
+	if err := driver.InsertCpes(models.NVD, cpes); err != nil {
+		return xerrors.Errorf("Failed to insert cpes. err: %w", err)
 	}
 
 	fetchMeta.LastFetchedAt = time.Now()

--- a/db/common_test.go
+++ b/db/common_test.go
@@ -6,58 +6,31 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/knqyf263/go-cpe/common"
-	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
 
 	"github.com/vulsio/go-cpe-dictionary/models"
 )
 
 func prepareTestData(driver DB) error {
-	var testCpeStrings = []struct {
-		cpe        string
-		deprecated bool
-	}{
-		{`cpe:2.3:a:ntp:ntp:4.2.5p48:*:*:*:*:*:*:*`, false},
-		{`cpe:2.3:a:ntp:ntp:4.2.8:p1-beta1:*:*:*:*:*:*`, false},
-		{`cpe:2.3:a:responsive_coming_soon_page_project:responsive_coming_soon_page:1.1.18:*:*:*:*:wordpress:*:*`, false},
-		{`cpe:2.3:a:vendorName1:productName1-1:1.1:*:*:*:*:targetSoftware1:targetHardware1:*`, false},
-		{`cpe:2.3:a:vendorName1:productName1-2:1.2:*:*:*:*:targetSoftware1:targetHardware1:*`, false},
-		{"cpe:2.3:a:vendorName2:productName2:2.0:*:*:*:*:targetSoftware2:targetHardware2:*", false},
-		{"cpe:2.3:a:vendorName3:productName3:3.0:*:*:*:*:targetSoftware3:targetHardware3:*", false},
-		{"cpe:2.3:a:vendorName4:productName4:4.0:*:*:*:*:targetSoftware4:targetHardware4:*", false},
-		{"cpe:2.3:a:vendorName5:productName5:5.0:*:*:*:*:targetSoftware5:targetHardware5:*", false},
-		{"cpe:2.3:a:vendorName6:productName6:6.0:*:*:*:*:targetSoftware6:targetHardware6:*", false},
-		{"cpe:2.3:a:vendorName6:productName6:6.1:*:*:*:*:targetSoftware6:targetHardware6:*", true},
-		{`cpe:2.3:a:mongodb:c\#_driver:1.10.0:-:*:*:*:mongodb:*:*`, false},
+	var testCpes = models.FetchedCPEs{
+		CPEs: []string{
+			`cpe:2.3:a:ntp:ntp:4.2.5p48:*:*:*:*:*:*:*`,
+			`cpe:2.3:a:ntp:ntp:4.2.8:p1-beta1:*:*:*:*:*:*`,
+			`cpe:2.3:a:responsive_coming_soon_page_project:responsive_coming_soon_page:1.1.18:*:*:*:*:wordpress:*:*`,
+			`cpe:2.3:a:vendorName1:productName1-1:1.1:*:*:*:*:targetSoftware1:targetHardware1:*`,
+			`cpe:2.3:a:vendorName1:productName1-2:1.2:*:*:*:*:targetSoftware1:targetHardware1:*`,
+			`cpe:2.3:a:vendorName2:productName2:2.0:*:*:*:*:targetSoftware2:targetHardware2:*`,
+			`cpe:2.3:a:vendorName3:productName3:3.0:*:*:*:*:targetSoftware3:targetHardware3:*`,
+			`cpe:2.3:a:vendorName4:productName4:4.0:*:*:*:*:targetSoftware4:targetHardware4:*`,
+			`cpe:2.3:a:vendorName5:productName5:5.0:*:*:*:*:targetSoftware5:targetHardware5:*`,
+			`cpe:2.3:a:vendorName6:productName6:6.0:*:*:*:*:targetSoftware6:targetHardware6:*`,
+			`cpe:2.3:a:mongodb:c\#_driver:1.10.0:-:*:*:*:mongodb:*:*`,
+		},
+		Deprecated: []string{
+			`cpe:2.3:a:vendorName6:productName6:6.1:*:*:*:*:targetSoftware6:targetHardware6:*`,
+		},
 	}
-
-	testCpes := []models.CategorizedCpe{}
-
-	for _, t := range testCpeStrings {
-		wfn, err := naming.UnbindFS(t.cpe)
-		if err != nil {
-			return err
-		}
-
-		testCpes = append(testCpes, models.CategorizedCpe{
-			CpeURI:          naming.BindToURI(wfn),
-			CpeFS:           naming.BindToFS(wfn),
-			Part:            wfn.GetString(common.AttributePart),
-			Vendor:          wfn.GetString(common.AttributeVendor),
-			Product:         wfn.GetString(common.AttributeProduct),
-			Version:         wfn.GetString(common.AttributeVersion),
-			Update:          wfn.GetString(common.AttributeUpdate),
-			Edition:         wfn.GetString(common.AttributeEdition),
-			Language:        wfn.GetString(common.AttributeLanguage),
-			SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
-			TargetSoftware:  wfn.GetString(common.AttributeTargetSw),
-			TargetHardware:  wfn.GetString(common.AttributeTargetHw),
-			Other:           wfn.GetString(common.AttributeOther),
-			Deprecated:      t.deprecated,
-		})
-	}
-
+	viper.Set("threads", 1)
 	viper.Set("batch-size", 1)
 	return driver.InsertCpes(models.NVD, testCpes)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -22,7 +22,7 @@ type DB interface {
 
 	GetVendorProducts() ([]models.VendorProduct, []models.VendorProduct, error)
 	GetCpesByVendorProduct(string, string) ([]string, []string, error)
-	InsertCpes(models.FetchType, []models.CategorizedCpe) error
+	InsertCpes(models.FetchType, models.FetchedCPEs) error
 	IsDeprecated(string) (bool, error)
 }
 

--- a/db/rdb_test.go
+++ b/db/rdb_test.go
@@ -36,7 +36,6 @@ func TestGetCpesByVendorProductSqlite(t *testing.T) {
 
 // TestGetCpesByVendorProductSqliteFuzzy includes a % for some simple fuzzy matches not supported by all drivers.
 func TestGetCpesByVendorProductSqliteFuzzy(t *testing.T) {
-
 	driver, _, err := NewDB("sqlite3", ":memory:", false, Option{})
 	if err != nil {
 		t.Error(err)

--- a/fetcher/jvn.go
+++ b/fetcher/jvn.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/inconshreveable/log15"
+	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
@@ -45,6 +47,11 @@ func FetchJVN() (models.FetchedCPEs, error) {
 	for _, rdf := range rdfs {
 		for _, item := range rdf.Items {
 			for _, c := range item.Cpes {
+				if _, err := naming.UnbindURI(c.Value); err != nil {
+					// Logging only
+					log15.Warn("Failed to unbind", c.Value, err)
+					continue
+				}
 				cpeURIs[c.Value] = struct{}{}
 			}
 		}

--- a/fetcher/jvn.go
+++ b/fetcher/jvn.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/inconshreveable/log15"
-	"github.com/knqyf263/go-cpe/common"
-	"github.com/knqyf263/go-cpe/naming"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 
 	"github.com/vulsio/go-cpe-dictionary/models"
@@ -32,39 +30,26 @@ type cpe struct {
 }
 
 // FetchJVN JVN feeds
-func FetchJVN() ([]models.CategorizedCpe, error) {
+func FetchJVN() (models.FetchedCPEs, error) {
 	years, err := util.GetYearsUntilThisYear(2002)
 	if err != nil {
-		return nil, err
+		return models.FetchedCPEs{}, err
 	}
 	urls := makeJvnURLs(years)
 
-	cpeURIs := map[string]models.CategorizedCpe{}
+	cpeURIs := map[string]struct{}{}
 	rdfs, err := fetchJVNFeedFileConcurrently(urls, viper.GetInt("threads"), viper.GetInt("wait"))
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to get feeds. err: %w", err)
+		return models.FetchedCPEs{}, xerrors.Errorf("Failed to get feeds. err: %w", err)
 	}
 	for _, rdf := range rdfs {
 		for _, item := range rdf.Items {
-			cpes, err := convertJvnCpesToModel(item.Cpes)
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to convert. err: %w", err)
-			}
-
-			for _, c := range cpes {
-				if _, ok := cpeURIs[c.CpeURI]; !ok {
-					cpeURIs[c.CpeURI] = c
-				}
+			for _, c := range item.Cpes {
+				cpeURIs[c.Value] = struct{}{}
 			}
 		}
 	}
-
-	allCpes := []models.CategorizedCpe{}
-	for _, c := range cpeURIs {
-		allCpes = append(allCpes, c)
-	}
-
-	return allCpes, nil
+	return models.FetchedCPEs{CPEs: maps.Keys(cpeURIs)}, nil
 }
 
 func makeJvnURLs(years []int) (urls []string) {
@@ -141,36 +126,8 @@ func fetchJVNFeedFile(url string) (rdf *rdf, err error) {
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to fetch. url: %s, err: %w", url, err)
 	}
-	if err = xml.Unmarshal(bytes, &rdf); err != nil {
+	if err := xml.Unmarshal(bytes, &rdf); err != nil {
 		return nil, xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", url, err)
 	}
 	return rdf, nil
-}
-
-func convertJvnCpesToModel(jvnCpes []cpe) (cpes []models.CategorizedCpe, err error) {
-	for _, c := range jvnCpes {
-		var wfn common.WellFormedName
-		if wfn, err = naming.UnbindURI(c.Value); err != nil {
-			// Logging only
-			log15.Warn("Failed to unbind", c.Value, err)
-			continue
-		}
-		cpes = append(cpes, models.CategorizedCpe{
-			FetchType:       models.JVN,
-			CpeURI:          naming.BindToURI(wfn),
-			CpeFS:           naming.BindToFS(wfn),
-			Part:            wfn.GetString(common.AttributePart),
-			Vendor:          wfn.GetString(common.AttributeVendor),
-			Product:         wfn.GetString(common.AttributeProduct),
-			Version:         wfn.GetString(common.AttributeVersion),
-			Update:          wfn.GetString(common.AttributeUpdate),
-			Edition:         wfn.GetString(common.AttributeEdition),
-			Language:        wfn.GetString(common.AttributeLanguage),
-			SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
-			TargetSoftware:  wfn.GetString(common.AttributeTargetSw),
-			TargetHardware:  wfn.GetString(common.AttributeTargetHw),
-			Other:           wfn.GetString(common.AttributeOther),
-		})
-	}
-	return cpes, nil
 }

--- a/fetcher/nvd.go
+++ b/fetcher/nvd.go
@@ -5,263 +5,137 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
-	"io/ioutil"
-	"time"
+	"errors"
+	"io"
 
 	"github.com/inconshreveable/log15"
-	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/parnurzeal/gorequest"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 
 	"github.com/vulsio/go-cpe-dictionary/models"
-	"github.com/vulsio/go-cpe-dictionary/util"
 )
 
-// CpeDictionary has cpe-item list
+// cpeDictionary has cpe-item list
 // https://nvd.nist.gov/cpe.cfm
-type CpeDictionary struct {
-	Items []struct {
-		Name       string `xml:"name,attr"`
-		Deprecated string `xml:"deprecated,attr"`
-		Cpe23Item  struct {
-			Name string `xml:"name,attr"`
-		} `xml:"cpe23-item"`
-	} `xml:"cpe-item"`
+type cpeDictionaryItem struct {
+	Name       string `xml:"name,attr"`
+	Deprecated string `xml:"deprecated,attr"`
+	Cpe23Item  struct {
+		Name string `xml:"name,attr"`
+	} `xml:"cpe23-item"`
 }
 
-// V3Feed : NvdV3Feed
-// https://scap.nist.gov/schema/nvd/feed/0.1/nvd_cve_feed_json_0.1_beta.schema
-type V3Feed struct {
-	CVEItems []struct {
-		Configurations struct {
-			Nodes []struct {
-				Cpe []struct {
-					Cpe23URI string `json:"cpe23Uri"`
-				} `json:"cpe_match"`
-			} `json:"nodes"`
-		} `json:"configurations"`
-	} `json:"CVE_Items"`
+// cpeMatch : https://csrc.nist.gov/schema/cpematch/feed/1.0/nvd_cpematch_feed_json_1.0.schema
+type cpeMatchElement struct {
+	Cpe23URI string `json:"cpe23Uri"`
 }
 
 // FetchNVD NVD feeds
-func FetchNVD() ([]models.CategorizedCpe, error) {
-	cpeURIs := map[string]models.CategorizedCpe{}
-
-	dictCpes, err := FetchCpeDictionary()
-	if err != nil {
-		return nil, xerrors.Errorf("Failed to fetch cpe dictionary. err: %w", err)
+func FetchNVD() (models.FetchedCPEs, error) {
+	cpes := map[string]struct{}{}
+	deprecateds := map[string]struct{}{}
+	if err := fetchCpeDictionary(cpes, deprecateds); err != nil {
+		return models.FetchedCPEs{}, xerrors.Errorf("Failed to fetch cpe dictionary. err: %w", err)
 	}
-	for _, c := range dictCpes {
-		if _, ok := cpeURIs[c.CpeURI]; !ok {
-			cpeURIs[c.CpeURI] = c
-		}
+	if err := fetchCpeMatch(cpes); err != nil {
+		return models.FetchedCPEs{}, xerrors.Errorf("Failed to fetch cpe match. err: %w", err)
 	}
-
-	jsonCpes, err := FetchJSONFeed()
-	if err != nil {
-		return nil, xerrors.Errorf("Failed to fetch nvd JSON feed. err: %w", err)
-	}
-	for _, c := range jsonCpes {
-		if _, ok := cpeURIs[c.CpeURI]; !ok {
-			cpeURIs[c.CpeURI] = c
-		}
-	}
-
-	allCpes := []models.CategorizedCpe{}
-	for _, c := range cpeURIs {
-		allCpes = append(allCpes, c)
-	}
-
-	return allCpes, nil
+	return models.FetchedCPEs{CPEs: maps.Keys(cpes), Deprecated: maps.Keys(deprecateds)}, nil
 }
 
-// FetchCpeDictionary : FetchCpeDictionary
-func FetchCpeDictionary() ([]models.CategorizedCpe, error) {
+func fetchCpeDictionary(cpes, deprecated map[string]struct{}) error {
 	url := "http://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
 	log15.Info("Fetching...", "URL", url)
-	resp, body, errs := gorequest.New().Proxy(viper.GetString("http-proxy")).Get(url).End()
+	resp, bs, errs := gorequest.New().Proxy(viper.GetString("http-proxy")).Get(url).EndBytes()
 	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
-		return nil, xerrors.Errorf("HTTP error. errs: %v, url: %s", errs, url)
+		return xerrors.Errorf("HTTP error. errs: %v, url: %s", errs, url)
 	}
 
-	b := bytes.NewBufferString(body)
-	reader, err := gzip.NewReader(b)
-	defer func() {
-		_ = reader.Close()
-	}()
+	r, err := gzip.NewReader(bytes.NewReader(bs))
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to decompress NVD feedfile. url: %s, err: %w", url, err)
+		return xerrors.Errorf("Failed to decompress CPE Dictionary. url: %s, err: %w", url, err)
 	}
-	bytes, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return nil, xerrors.Errorf("Failed to Read NVD feedfile. url: %s, err: %w", url, err)
-	}
+	defer r.Close()
 
-	var cpeDictionary CpeDictionary
-	if err = xml.Unmarshal(bytes, &cpeDictionary); err != nil {
-		return nil, xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", url, err)
-	}
-
-	var cpes []models.CategorizedCpe
-	if cpes, err = convertNvdCpeDictionaryToModel(cpeDictionary); err != nil {
-		return nil, err
-	}
-
-	return cpes, nil
-}
-
-// FetchJSONFeed : FetchJSONFeed
-func FetchJSONFeed() ([]models.CategorizedCpe, error) {
-	startYear := 2002
-	years, err := util.GetYearsUntilThisYear(startYear)
-	if err != nil {
-		return nil, err
-	}
-
-	allCpes := []models.CategorizedCpe{}
-	urls := makeFeedURLBlocks(years)
-	nvds, err := fetchNVDFeedFileConcurrently(urls, viper.GetInt("threads"), viper.GetInt("wait"))
-	if err != nil {
-		return nil, xerrors.Errorf("Failed to get feeds. err: %w", err)
-	}
-	cpes, err := convertNvdV3FeedToModel(nvds)
-	if err != nil {
-		return nil, err
-	}
-	allCpes = append(allCpes, cpes...)
-	return allCpes, nil
-}
-
-// makeFeedURLBlocks : makeFeedURLBlocks
-func makeFeedURLBlocks(years []int) (urls []string) {
-	formatTemplate := "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz"
-	for _, year := range years {
-		urls = append(urls, fmt.Sprintf(formatTemplate, year))
-	}
-	return urls
-}
-
-func fetchNVDFeedFileConcurrently(urls []string, concurrency, wait int) (nvds []V3Feed, err error) {
-	reqChan := make(chan string, len(urls))
-	resChan := make(chan V3Feed, len(urls))
-	errChan := make(chan error, len(urls))
-	defer close(reqChan)
-	defer close(resChan)
-	defer close(errChan)
-
-	go func() {
-		for _, url := range urls {
-			reqChan <- url
-		}
-	}()
-
-	tasks := util.GenWorkers(concurrency, wait)
-	for range urls {
-		tasks <- func() {
-			select {
-			case url := <-reqChan:
-				nvd, err := fetchNVDFeedFile(url)
-				if err != nil {
-					errChan <- err
-					return
-				}
-				resChan <- *nvd
+	d := xml.NewDecoder(r)
+	for {
+		t, err := d.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return xerrors.Errorf("Failed to return next XML token. err: %w", err)
+		}
+		switch se := t.(type) {
+		case xml.StartElement:
+			if se.Name.Local != "cpe-item" {
+				break
+			}
+			var item cpeDictionaryItem
+			if err := d.DecodeElement(&item, &se); err != nil {
+				return xerrors.Errorf("Failed to decode. url: %s, err: %w", url, err)
+			}
+			if _, err := naming.UnbindFS(item.Cpe23Item.Name); err != nil {
+				// Logging only
+				log15.Warn("Failed to unbind", item.Cpe23Item.Name, err)
+				continue
+			}
+			if item.Deprecated == "true" {
+				deprecated[item.Cpe23Item.Name] = struct{}{}
+			} else {
+				cpes[item.Cpe23Item.Name] = struct{}{}
+			}
+		default:
 		}
 	}
-
-	errs := []error{}
-	timeout := time.After(10 * 60 * time.Second)
-	for range urls {
-		select {
-		case nvd := <-resChan:
-			nvds = append(nvds, nvd)
-		case err := <-errChan:
-			errs = append(errs, err)
-		case <-timeout:
-			return nvds, xerrors.Errorf("Timeout Fetching Nvd")
-		}
-	}
-	if 0 < len(errs) {
-		return nvds, xerrors.Errorf("%s", errs)
-	}
-	return nvds, nil
+	return nil
 }
 
-func fetchNVDFeedFile(url string) (nvd *V3Feed, err error) {
-	bytes, err := util.FetchFeedFile(url, true)
+func fetchCpeMatch(cpes map[string]struct{}) error {
+	url := "https://nvd.nist.gov/feeds/json/cpematch/1.0/nvdcpematch-1.0.json.gz"
+	log15.Info("Fetching...", "URL", url)
+	resp, bs, errs := gorequest.New().Proxy(viper.GetString("http-proxy")).Get(url).EndBytes()
+	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
+		return xerrors.Errorf("HTTP error. errs: %v, url: %s", errs, url)
+	}
+
+	r, err := gzip.NewReader(bytes.NewReader(bs))
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to fetch. url: %s, err: %w", url, err)
+		return xerrors.Errorf("Failed to decompress CPE Match. url: %s, err: %w", url, err)
 	}
-	if err = json.Unmarshal(bytes, &nvd); err != nil {
-		return nil, xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", url, err)
-	}
-	return nvd, nil
-}
+	defer r.Close()
 
-// convertNvdCpeDictionaryToModel :
-func convertNvdCpeDictionaryToModel(nvd CpeDictionary) (cpes []models.CategorizedCpe, err error) {
-	for _, item := range nvd.Items {
-		var wfn common.WellFormedName
-		if wfn, err = naming.UnbindFS(item.Cpe23Item.Name); err != nil {
+	d := json.NewDecoder(r)
+	if _, err := d.Token(); err != nil { // json.Delim: {
+		return xerrors.Errorf("Failed to return next JSON token. err: %w", err)
+	}
+	if _, err := d.Token(); err != nil { // string: matches
+		return xerrors.Errorf("Failed to return next JSON token. err: %w", err)
+	}
+	if _, err := d.Token(); err != nil { // json.Delim: [
+		return xerrors.Errorf("Failed to return next JSON token. err: %w", err)
+	}
+	for d.More() {
+		var cpeMatch cpeMatchElement
+		if err := d.Decode(&cpeMatch); err != nil {
+			return xerrors.Errorf("Failed to decode. url: %s, err: %w", url, err)
+		}
+		if _, err := naming.UnbindFS(cpeMatch.Cpe23URI); err != nil {
 			// Logging only
-			log15.Warn("Failed to unbind", item.Cpe23Item.Name, err)
+			log15.Warn("Failed to unbind", cpeMatch.Cpe23URI, err)
 			continue
 		}
-		cpes = append(cpes, models.CategorizedCpe{
-			FetchType:       models.NVD,
-			CpeURI:          naming.BindToURI(wfn),
-			CpeFS:           naming.BindToFS(wfn),
-			Part:            wfn.GetString(common.AttributePart),
-			Vendor:          wfn.GetString(common.AttributeVendor),
-			Product:         wfn.GetString(common.AttributeProduct),
-			Version:         wfn.GetString(common.AttributeVersion),
-			Update:          wfn.GetString(common.AttributeUpdate),
-			Edition:         wfn.GetString(common.AttributeEdition),
-			Language:        wfn.GetString(common.AttributeLanguage),
-			SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
-			TargetSoftware:  wfn.GetString(common.AttributeTargetSw),
-			TargetHardware:  wfn.GetString(common.AttributeTargetHw),
-			Other:           wfn.GetString(common.AttributeOther),
-			Deprecated:      item.Deprecated == "true",
-		})
+		cpes[cpeMatch.Cpe23URI] = struct{}{}
 	}
-	return cpes, nil
-}
+	if _, err := d.Token(); err != nil { // json.Delim: ]
+		return xerrors.Errorf("Failed to return next JSON token. err: %w", err)
+	}
+	if _, err := d.Token(); err != nil { // json.Delim: }
+		return xerrors.Errorf("Failed to return next JSON token. err: %w", err)
+	}
 
-// convertNvdV3FeedToModel :
-func convertNvdV3FeedToModel(nvds []V3Feed) (cpes []models.CategorizedCpe, err error) {
-	for _, nvd := range nvds {
-		for _, item := range nvd.CVEItems {
-			for _, node := range item.Configurations.Nodes {
-				for _, cpe := range node.Cpe {
-					var wfn common.WellFormedName
-					if wfn, err = naming.UnbindFS(cpe.Cpe23URI); err != nil {
-						log15.Warn("Failed to unbind cpe.", "CPE URI", cpe.Cpe23URI, "err", err)
-						continue
-					}
-					cpes = append(cpes, models.CategorizedCpe{
-						FetchType:       models.NVD,
-						CpeURI:          naming.BindToURI(wfn),
-						CpeFS:           naming.BindToFS(wfn),
-						Part:            wfn.GetString(common.AttributePart),
-						Vendor:          wfn.GetString(common.AttributeVendor),
-						Product:         wfn.GetString(common.AttributeProduct),
-						Version:         wfn.GetString(common.AttributeVersion),
-						Update:          wfn.GetString(common.AttributeUpdate),
-						Edition:         wfn.GetString(common.AttributeEdition),
-						Language:        wfn.GetString(common.AttributeLanguage),
-						SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
-						TargetSoftware:  wfn.GetString(common.AttributeTargetSw),
-						TargetHardware:  wfn.GetString(common.AttributeTargetHw),
-						Other:           wfn.GetString(common.AttributeOther),
-					})
-				}
-			}
-		}
-	}
-	return cpes, nil
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/go-redis/redis/v8 v8.10.0
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.8
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f
 	github.com/labstack/echo v3.3.10+incompatible
@@ -16,6 +16,7 @@ require (
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gorm.io/driver/mysql v1.1.1
 	gorm.io/driver/postgres v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -605,6 +606,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 h1:x03zeu7B2B11ySp+daztnwM5oBJ/8wGUSqrwcw9L0RA=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/models/models.go
+++ b/models/models.go
@@ -77,12 +77,16 @@ func ConvertToModels(cpes []string, fetchType FetchType, deprecated bool) []Cate
 		}
 	}()
 
+	unbindFn := naming.UnbindFS
+	if fetchType == JVN {
+		unbindFn = naming.UnbindURI
+	}
 	tasks := util.GenWorkers(viper.GetInt("threads"), 0)
 	for range cpes {
 		tasks <- func() {
 			select {
 			case cpe := <-reqChan:
-				wfn, err := naming.UnbindFS(cpe)
+				wfn, err := unbindFn(cpe)
 				if err != nil {
 					resChan <- nil
 				}

--- a/models/models.go
+++ b/models/models.go
@@ -3,7 +3,12 @@ package models
 import (
 	"time"
 
+	"github.com/knqyf263/go-cpe/common"
+	"github.com/knqyf263/go-cpe/naming"
+	"github.com/spf13/viper"
 	"gorm.io/gorm"
+
+	"github.com/vulsio/go-cpe-dictionary/util"
 )
 
 // LatestSchemaVersion manages the Schema version used in the latest go-cpe-dictionary.
@@ -32,6 +37,12 @@ const (
 	JVN FetchType = "jvn"
 )
 
+// FetchedCPEs :
+type FetchedCPEs struct {
+	CPEs       []string
+	Deprecated []string
+}
+
 // CategorizedCpe :
 // https://cpe.mitre.org/specification/CPE_2.3_for_ITSAC_Nov2011.pdf
 type CategorizedCpe struct {
@@ -51,6 +62,61 @@ type CategorizedCpe struct {
 	TargetHardware  string    `gorm:"type:varchar(255)"`
 	Other           string    `gorm:"type:varchar(255)"`
 	Deprecated      bool
+}
+
+// ConvertToModels :
+func ConvertToModels(cpes []string, fetchType FetchType, deprecated bool) []CategorizedCpe {
+	reqChan := make(chan string, len(cpes))
+	resChan := make(chan *CategorizedCpe, len(cpes))
+	defer close(reqChan)
+	defer close(resChan)
+
+	go func() {
+		for _, cpe := range cpes {
+			reqChan <- cpe
+		}
+	}()
+
+	tasks := util.GenWorkers(viper.GetInt("threads"), 0)
+	for range cpes {
+		tasks <- func() {
+			select {
+			case cpe := <-reqChan:
+				wfn, err := naming.UnbindFS(cpe)
+				if err != nil {
+					resChan <- nil
+				}
+				resChan <- &CategorizedCpe{
+					FetchType:       fetchType,
+					CpeURI:          naming.BindToURI(wfn),
+					CpeFS:           naming.BindToFS(wfn),
+					Part:            wfn.GetString(common.AttributePart),
+					Vendor:          wfn.GetString(common.AttributeVendor),
+					Product:         wfn.GetString(common.AttributeProduct),
+					Version:         wfn.GetString(common.AttributeVersion),
+					Update:          wfn.GetString(common.AttributeUpdate),
+					Edition:         wfn.GetString(common.AttributeEdition),
+					Language:        wfn.GetString(common.AttributeLanguage),
+					SoftwareEdition: wfn.GetString(common.AttributeSwEdition),
+					TargetSoftware:  wfn.GetString(common.AttributeTargetSw),
+					TargetHardware:  wfn.GetString(common.AttributeTargetHw),
+					Other:           wfn.GetString(common.AttributeOther),
+					Deprecated:      deprecated,
+				}
+			}
+		}
+	}
+
+	var converted []CategorizedCpe
+	for range cpes {
+		select {
+		case cpe := <-resChan:
+			if cpe != nil {
+				converted = append(converted, *cpe)
+			}
+		}
+	}
+	return converted
 }
 
 // VendorProduct :

--- a/util/util.go
+++ b/util/util.go
@@ -3,7 +3,7 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -135,7 +135,7 @@ func FetchFeedFile(url string, compressed bool) ([]byte, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to decompress NVD feedfile. url: %s, err: %w", url, err)
 	}
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to Read NVD feedfile. url: %s, err: %w", url, err)
 	}


### PR DESCRIPTION
# What did you implement:

Until now, NVD Fetch has had problems such as high memory usage. This PR reduces memory usage.
The memory usage has been reduced from 3 GB to 400 MB.
Also, previously the JSON Feeds for each year were retrieved, but now the CPE Match Feed is retrieved.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ go-cpe-dictionary version
go-cpe-dictionary v0.5.0 59c88e6
$ /usr/bin/time -f "real(s): %e, memory(kB): %M" go-cpe-dictionary fetch nvd --batch-size 500
INFO[07-21|23:57:55] Inserting new CPEs 
1008164 / 1008164 [------------------------------------------] 100.00% 19523 p/s
INFO[07-21|23:58:47] Inserted 1008164 CPEs 
real(s): 126.02, memory(kB): 3061784
```

## after
```console
$ go-cpe-dictionary version
go-cpe-dictionary v0.5.0 a36553b
$ /usr/bin/time -f "real(s): %e, memory(kB): %M" go-cpe-dictionary fetch nvd --batch-size 500
...
INFO[07-21|23:54:50] Inserting new CPEs 
1046824 / 1046824 [------------------------------------------] 100.00% 18516 p/s
real(s): 104.32, memory(kB): 379104
```
# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

