### PR TITLE
fix(db/test): no parallel testing

### DIFF
--- a/db/redis_test.go
+++ b/db/redis_test.go
@@ -25,7 +25,6 @@ func teardownRedis(s *miniredis.Miniredis, driver DB) {
 }
 
 func TestGetVendorProductsRedis(t *testing.T) {
-	t.Parallel()
 	s, driver, err := setupRedis()
 	if err != nil {
 		t.Errorf("Failed to parepare redis: %s", err)
@@ -36,7 +35,6 @@ func TestGetVendorProductsRedis(t *testing.T) {
 }
 
 func TestGetCpesByVendorProductRedis(t *testing.T) {
-	t.Parallel()
 	s, driver, err := setupRedis()
 	if err != nil {
 		t.Errorf("Failed to parepare redis: %s", err)
@@ -47,7 +45,6 @@ func TestGetCpesByVendorProductRedis(t *testing.T) {
 }
 
 func TestGetSimilarCpesByTitle(t *testing.T) {
-	t.Parallel()
 	s, driver, err := setupRedis()
 	if err != nil {
 		t.Errorf("Failed to parepare redis: %s", err)
@@ -58,7 +55,6 @@ func TestGetSimilarCpesByTitle(t *testing.T) {
 }
 
 func TestRedisDriver_IsDeprecated(t *testing.T) {
-	t.Parallel()
 	s, driver, err := setupRedis()
 	if err != nil {
 		t.Errorf("Failed to parepare redis: %s", err)


### PR DESCRIPTION
Some CI test fails rarely, and "go test -race -v ./..." detects following races:

```
[snip]
WARNING: DATA RACE
Write at 0x00c000350ab0 by goroutine 188:
  runtime.mapassign_faststr()
      /home/shino/sdk/go1.23.3/src/runtime/map_faststr.go:223 +0x0
  github.com/spf13/viper.(*Viper).Set()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:1627 +0x34b
  github.com/spf13/viper.Set()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:1615 +0x997
  github.com/vulsio/go-cpe-dictionary/db.prepareTestData()
      /home/shino/g/go-cpe-dictionary/db/common_test.go:70 +0x965
  github.com/vulsio/go-cpe-dictionary/db.testGetSimilarCpesByTitle()
      /home/shino/g/go-cpe-dictionary/db/common_test.go:217 +0x59
  github.com/vulsio/go-cpe-dictionary/db.TestGetSimilarCpesByTitle()
      /home/shino/g/go-cpe-dictionary/db/redis_test.go:57 +0x196
  testing.tRunner()
      /home/shino/sdk/go1.23.3/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/shino/sdk/go1.23.3/src/testing/testing.go:1743 +0x44
Previous read at 0x00c000350ab0 by goroutine 189:
  runtime.mapaccess2_faststr()
      /home/shino/sdk/go1.23.3/src/runtime/map_faststr.go:117 +0x0
  github.com/spf13/viper.(*Viper).searchMap()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:669 +0x8a
  github.com/spf13/viper.(*Viper).find()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:1314 +0x24a
  github.com/spf13/viper.(*Viper).Get()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:904 +0x75
  github.com/spf13/viper.(*Viper).GetInt()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:992 +0x3a
  github.com/spf13/viper.GetInt()
      /home/shino/go/pkg/mod/github.com/spf13/viper@v1.19.0/viper.go:989 +0x324
  github.com/vulsio/go-cpe-dictionary/models.ConvertToModels()
      /home/shino/g/go-cpe-dictionary/models/models.go:93 +0x325
[snip]
```

# What did you implement:

Remove t.Parallel to execute unit tests serially.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

