### PR TITLE
fix(ci/release): grant contents:write to goreleaser job

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
## Summary
- The goreleaser workflow failed on the `v0.9.5` tag push ([run 25646918221](https://github.com/vulsio/go-cpe-dictionary/actions/runs/25646918221)) with `403 Resource not accessible by integration` when publishing the GitHub Release, because `GITHUB_TOKEN` had only read-only default permissions.
- Deny everything at the workflow level (`permissions: {}`) and grant `contents: write` only to the `goreleaser` job, following the least-privilege principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)